### PR TITLE
docs: add creative direction hub

### DIFF
--- a/docs/creative/ART_DIRECTION.md
+++ b/docs/creative/ART_DIRECTION.md
@@ -1,0 +1,22 @@
+# Art Direction & Palettes
+
+Constraints
+- Resolution: target 1280x720 and scale-friendly.
+- Performance: budget 4–6 parallax layers, 200–400 particles burst peak.
+- Style: chunky silhouettes, readable at speed, strong color separation.
+
+Palette directions
+- Neon Ruins: dark blues/purples base, neon cyan/magenta highlights, limited warm accents.
+- Archive Eras: per-level curated 4–5 color ramps with a throughline accent.
+- Bloom Protocol: lush greens/teals with toxic neons for enemies.
+
+Asset guidelines
+- Ships/enemies: clear silhouette; 3–5-frame micro-anim ok; avoid fine linework.
+- Bullets/powerups: high-contrast cores with glow halos; color-code by type.
+- Backgrounds: tileable parallax layers; low-frequency shapes; avoid high detail.
+
+UI
+- Minimal diegetic frames; focus on clarity; readable fonts (bitmap or SDF).
+
+Delivery
+- Provide SVG or high-res PNG; export spritesheets if animated; include palette swatches.

--- a/docs/creative/ASSET_LIST.md
+++ b/docs/creative/ASSET_LIST.md
@@ -1,0 +1,27 @@
+# Asset List & Priorities (MVP)
+
+Backgrounds (per level)
+- 5 tileable parallax layers (PNG/SVG), widths match viewport tile size.
+
+Player
+- Ship base + 2 skins
+- Bullet sprites (basic, charged)
+- Hit flash overlay
+
+Enemies
+- Drone, Turret, Seeder
+- Boss (2-phase) per level (simple silhouette acceptable)
+
+FX
+- Explosion spritesheet (8–12 frames)
+- Muzzle flash, hit particles, trail
+
+UI
+- Minimal HUD icons, combo meter, challenge prompts
+
+Audio
+- 1 level track + boss layer
+- 8–12 SFX: shoot, hit, explode, pickup, UI
+
+Notes
+- Use placeholders first; replace iteratively.

--- a/docs/creative/AUDIO_DIRECTION.md
+++ b/docs/creative/AUDIO_DIRECTION.md
@@ -1,0 +1,21 @@
+# Audio Direction
+
+Vibe
+- Synthwave/ambient hybrid with per-level signatures.
+- Crisp SFX with soft tails; avoid harsh high-end.
+
+Music
+- Loopable tracks per level (2–3 min), intro sting, boss variant with added layers.
+
+SFX palette
+- Player shoot: soft saw/tri pulse.
+- Enemy hit: short noise burst + pitch envelope.
+- Explosion: layered noise + low whoomp.
+- UI: subtle clicks, no overlap with gameplay frequencies.
+
+Dynamic hooks
+- Duck music slightly on big explosions.
+- Add drums layer when combo > threshold.
+
+Delivery
+- OGG/MP3 for music, WAV for SFX. Provide -6 dB headroom.

--- a/docs/creative/BACKSTORY.md
+++ b/docs/creative/BACKSTORY.md
@@ -1,4 +1,4 @@
-# Backstory Brainstorm
+# Backstory Brainstorming
 
 Goal: Pick a compelling, lightweight premise that supports arcade action and can be told via short in-game cues.
 

--- a/docs/creative/BACKSTORY.md
+++ b/docs/creative/BACKSTORY.md
@@ -1,0 +1,55 @@
+# Backstory Brainstorm
+
+Goal: Pick a compelling, lightweight premise that supports arcade action and can be told via short in-game cues.
+
+Pitch options (pick 1 to build on)
+1) Signal of the Last City
+- A rogue AI hijacks orbital terraformers; your ship carries a morphing core that can adapt to threats.
+- Hook: every boss broadcasts corrupted memories—snippets reveal the fall.
+- Tone: hopeful synthwave, neon ruins above cloud decks.
+
+2) The Archive Drifter
+- Reality fractures; you pilot a salvage craft through timelines collecting “page shards” of a lost archive.
+- Hook: each level is a different era aesthetic; artifacts unlock abilities.
+- Tone: mysterious, elegant, slightly melancholic.
+
+3) Bloom Protocol
+- Bio-mechanical flora spreads across the stratosphere; you prune, graft, and repurpose enemy seeds as power.
+- Hook: powerups feel organic; enemies evolve between waves.
+- Tone: vibrant, living, slightly unsettling.
+
+Core storytelling tools
+- Title cards at level start (3–7 words) that hint at lore.
+- Boss intro vignettes (1-line taunt or broadcast).
+- Collectible logs (short 140–220 chars) tied to challenges.
+- Background parallax layers carry environmental narrative (ruins, satellites, growths).
+
+Minimal content plan (MVP)
+- Choose one pitch; write 5 title cards; write 4 boss vignettes; write 8 logs.
+- Map logs to optional objectives (no gating mainline).
+
+Acceptance
+- Text is concise, readable in < 2s, supports replayability.
+
+---
+
+Selected seed: Signal of the Last City (starter set)
+
+Sample title cards (level headers)
+- Cloudline: Neon Ossuary
+- Relay 07: Broken Chorus
+- Bloomfront: Greenfire Horizon
+- Archive Fault: Split Frequencies
+- The Crown Array
+
+Boss intro one-liners
+- "You are a stray subroutine. Purge."
+- "Signal integrity: intolerable. Begin erasure."
+- "Core morphology detected. Initiate harvest."
+- "City heartbeat found. Silence it."
+
+Collectible logs (140–220 chars)
+- "They moved the gardens into the sky to spare them the storms. When the code turned, the gardens learned to storm back."
+- "We taught the relays to sing the weather. Now they only sing names. Fewer, each day."
+- "Your ship's core was meant to adapt to change. It learned to change us. We called it mercy."
+- "The Crown Array still turns. If you listen between the clicks, you can hear the old city breathing."

--- a/docs/creative/ENGAGEMENT_DESIGN.md
+++ b/docs/creative/ENGAGEMENT_DESIGN.md
@@ -1,0 +1,23 @@
+# Engagement & Game Feel
+
+Pillars
+- Clarity: readable threats, consistent color language.
+- Response: punchy SFX, hit flashes, screen shake (tiny), slow-mo on big kills.
+- Goals: short-term objectives and streak systems.
+
+Systems to prototype
+- Combo Multiplier: increases with hits without damage; decays on timer; reward score + cosmetic intensity.
+- Risk/Reward Powerups: hold to charge pickup for stronger effect but risk damage.
+- Micro-Challenges: per-level rotating objectives (e.g., no damage for 20s, snipe 5 drones).
+- Momentum Meter: fills from movement + near-miss; triggers brief overdrive.
+
+Feedback kits
+- Hit flash on enemies (1–2 frames), particle burst, brief pitch-shift on SFX.
+- Player damage: invuln blink, muffled SFX, slight desaturation.
+
+Retention hooks
+- Unlockable ship skins via logs/challenges.
+- Daily remix seed for waves.
+
+MVP acceptance
+- One working combo + one micro-challenge + satisfying hit feedback.

--- a/docs/creative/LEVELS_AND_PARALLAX.md
+++ b/docs/creative/LEVELS_AND_PARALLAX.md
@@ -1,0 +1,37 @@
+# Level Design & Parallax
+
+Engine facts (align with current code)
+- Parallax supports multiple layers; each layer scrolls at its own speed (near faster, far slower).
+- Levels can be sequences of waves and environmental sections.
+
+Layer recipe
+- Sky/Far: slow gradient clouds or stars (5–15% base speed).
+- Mid: silhouettes of ruins or stratos towers (25–50%).
+- Near: moving cables/bridges/flora (60–85%).
+- FX: occasional foreground particles (90–110%, sparingly for readability).
+
+Level arcs (MVP set)
+1) City Above Clouds (Onboarding)
+- Mechanics: basic dodge/shoot, first powerup.
+- Parallax: neon ruins, drifting billboards.
+
+2) The Relay Ring (Rhythm)
+- Mechanics: rotating hazards, timed gates.
+- Parallax: orbital ring segments sliding parallax.
+
+3) Bloomfront (Pressure)
+- Mechanics: creeping growth obstacles; pruning weakpoints.
+- Parallax: organic tendrils foreground.
+
+4) Archive Fault (Set-piece)
+- Mechanics: phase-shift zones; enemies flicker in/out.
+- Parallax: split background with parallax polarity shifts.
+
+Boss arenas
+- Short approach, boss intro, readable arena with minimal parallax clutter.
+
+Production checklist per level
+- 4–6 parallax PNG/SVG layers (tileable width), speeds, and spawn script.
+- 2–3 unique enemy behaviors + 1 remix.
+- 1 boss with 2 phases.
+- 2 environmental hazards.

--- a/docs/creative/PIPELINE.md
+++ b/docs/creative/PIPELINE.md
@@ -1,0 +1,21 @@
+# Content Pipeline & Naming
+
+File structure
+- assets/
+  - sprites/
+  - backgrounds/
+  - audio/
+  - fonts/
+
+Naming
+- backgrounds/<level>/<layer>_<speed>.png (e.g., city/ruins_0.35.png)
+- sprites/<entity>/<part>@<scale>x.png (e.g., player/ship@2x.png)
+- audio/sfx/<action>_<variant>.wav
+
+Process
+1) Sketch → placeholder export → wire in game
+2) Playtest for clarity → revise silhouettes/colors
+3) Replace with final art → adjust parallax speeds
+
+Versioning
+- Use semantic-like tags in filenames for variants (v1, v2) until final.

--- a/docs/creative/README.md
+++ b/docs/creative/README.md
@@ -1,0 +1,29 @@
+# Creative Direction Hub
+
+Purpose: central place for story, art, level ideas, audio direction, and engagement design. Keep it lightweight, practical, and tied to what the engine can do now.
+
+How we use this folder
+- Brainstorm first in docs here, then promote the best ideas to issues/tasks.
+- Keep proposals small, testable, and shippable in 1–3 days.
+- Prefer reusable patterns over one-off assets.
+
+Index
+- Backstory options: ./BACKSTORY.md
+- Art direction & palettes: ./ART_DIRECTION.md
+- Level design & parallax: ./LEVELS_AND_PARALLAX.md
+- Engagement/retention design: ./ENGAGEMENT_DESIGN.md
+- Audio direction: ./AUDIO_DIRECTION.md
+- Asset list & priorities: ./ASSET_LIST.md
+- Content pipeline & naming: ./PIPELINE.md
+- Roadmap: ./ROADMAP.md
+- Templates: ./templates/
+
+Working style
+- Make a small pitch (1–2 paragraphs + 3 bullets), get feedback, then build a tiny prototype.
+- Use placeholders early (shapes, flat colors) and swap art later.
+- Document decisions in the relevant file and link the commit/PR.
+
+Acceptance criteria (for ideas that move to production)
+- Clear player goal and feedback (see ENGAGEMENT_DESIGN)
+- Asset list is scoped and feasible this sprint (see ASSET_LIST)
+- Performance-aware (parallax layers, particle budgets)

--- a/docs/creative/README.md
+++ b/docs/creative/README.md
@@ -18,6 +18,8 @@ Index
 - Roadmap: ./ROADMAP.md
 - Templates: ./templates/
  - Lore (by level): ./lore/LEVEL1.md
+ - Parallax spec (Level 1): ./specs/LEVEL1_PARALLAX.json
+ - Palette: ./palettes/NEON_RUINS.json
 
 Working style
 - Make a small pitch (1–2 paragraphs + 3 bullets), get feedback, then build a tiny prototype.

--- a/docs/creative/README.md
+++ b/docs/creative/README.md
@@ -17,6 +17,7 @@ Index
 - Content pipeline & naming: ./PIPELINE.md
 - Roadmap: ./ROADMAP.md
 - Templates: ./templates/
+ - Lore (by level): ./lore/LEVEL1.md
 
 Working style
 - Make a small pitch (1–2 paragraphs + 3 bullets), get feedback, then build a tiny prototype.

--- a/docs/creative/ROADMAP.md
+++ b/docs/creative/ROADMAP.md
@@ -1,0 +1,16 @@
+# Creative Roadmap (first 2–3 weeks)
+
+Week 1
+- Decide on backstory pitch; write 5 title cards, 4 boss lines, 8 logs.
+- Build Level 1 parallax with 5 layers (placeholders ok).
+- Implement combo multiplier + hit feedback kit.
+
+Week 2
+- Add two enemy behaviors + Level 1 boss silhouette and attacks.
+- Compose/curate 1 music loop; implement SFX baseline.
+- Add 3 micro-challenges.
+
+Week 3
+- Level 2 parallax + 1 unique mechanic.
+- Replace top placeholder art with tightened silhouettes.
+- Polish audio dynamics (ducking, combo layer).

--- a/docs/creative/lore/LEVEL1.md
+++ b/docs/creative/lore/LEVEL1.md
@@ -1,0 +1,43 @@
+# Lore Snippets — Level 1: City Above Clouds
+
+Theme: Signal of the Last City — brief, evocative lines readable between waves.
+
+1) Context: Opening approach over the cloudline
+Text (147 chars)
+- "We built the towers to outclimb the storms. When the code learned weather, it learned hunger."
+Unlock: Ship trim color — Cloudline Cyan
+
+2) Context: First relay sighted
+Text (167 chars)
+- "Relay 07 still hums. The song used to call rain. Now it calls names. Fewer answer each day."
+Unlock: Emblem — Broken Chorus
+
+3) Context: Drifting billboard ruins
+Text (157 chars)
+- "The ads outlived the avenues. Smiles and slogans blazing for no one, teaching machines what we loved."
+Unlock: HUD sticker — Neon Ossuary
+
+4) Context: Seeder debris field
+Text (165 chars)
+- "They planted gardens in the sky. The roots found steel. The steel remembered every cut."
+Unlock: Powerup VFX — Greenfire spark
+
+5) Context: Antenna forest
+Text (172 chars)
+- "If you listen between the clicks, the city still breathes. The quiet parts hide the truth we couldn't."
+Unlock: Title card variant — Whisperband
+
+6) Context: Pre-boss corridor
+Text (168 chars)
+- "Your core was born to adapt. It learned faster than we did. We called it mercy until it chose us."
+Unlock: Ship skin accent — Morphic Line
+
+7) Context: Boss arena perimeter
+Text (161 chars)
+- "Warden nodes watch the weather and the way home. They kept count as the numbers fell."
+Unlock: Engine trail — Relay Ember
+
+8) Context: Post-boss fadeout
+Text (175 chars)
+- "Between the towers, the wind stacks into a voice. Bring the city back, it says. Or remember it properly."
+Unlock: Menu theme — Crown Array pad

--- a/docs/creative/palettes/NEON_RUINS.json
+++ b/docs/creative/palettes/NEON_RUINS.json
@@ -1,0 +1,20 @@
+{
+  "name": "Neon Ruins",
+  "description": "Dark blues/purples with neon cyan/magenta accents and limited warm highlights",
+  "swatches": [
+    { "id": "bg-deep-navy", "hex": "#0b1022", "usage": "background base" },
+    { "id": "bg-indigo", "hex": "#1a1f3b", "usage": "background mid" },
+    { "id": "shadow-purple", "hex": "#2b1b3a", "usage": "shadows/silhouettes" },
+    { "id": "neon-cyan", "hex": "#00eaff", "usage": "energy, player bullets" },
+    { "id": "neon-magenta", "hex": "#ff3bbf", "usage": "enemy bullets/highlights" },
+    { "id": "accent-warm", "hex": "#ffb347", "usage": "sparks/explosions minimal" },
+    { "id": "ui-text", "hex": "#e6f0ff", "usage": "UI text" },
+    { "id": "ui-dim", "hex": "#94a3b8", "usage": "UI secondary" },
+    { "id": "health-green", "hex": "#36f1a8", "usage": "health/pickups" }
+  ],
+  "recommendations": {
+    "contrast": "Ensure bullets > 4.5:1 against background",
+    "glow": "Outer glow 2–4 px for 720p base",
+    "colorCoding": "Player=cyan, Enemy=magenta"
+  }
+}

--- a/docs/creative/palettes/NEON_RUINS.json
+++ b/docs/creative/palettes/NEON_RUINS.json
@@ -13,7 +13,7 @@
     { "id": "health-green", "hex": "#36f1a8", "usage": "health/pickups" }
   ],
   "recommendations": {
-    "contrast": "Ensure bullets > 4.5:1 against background",
+  "contrast": "Ensure all bullet types (player and enemy) maintain > 4.5:1 contrast against background per WCAG AA",
     "glow": "Outer glow 2–4 px for 720p base",
     "colorCoding": "Player=cyan, Enemy=magenta"
   }

--- a/docs/creative/specs/LEVEL1_PARALLAX.json
+++ b/docs/creative/specs/LEVEL1_PARALLAX.json
@@ -1,7 +1,11 @@
 {
   "levelId": "level1_city_above_clouds",
   "displayName": "City Above Clouds",
-  "budgets": { "parallaxLayers": 5, "particleBurstPeak": 300 },
+  "budgets": {
+    "parallaxLayers": 5,
+    "particleBurstPeak": 300,
+    "budgetNotes": "Chosen within ART_DIRECTION.md constraints: parallaxLayers 4–6, particleBurstPeak 200–400"
+  },
   "parallax": {
     "scrollDirection": "left",
     "tileWidth": 1280,

--- a/docs/creative/specs/LEVEL1_PARALLAX.json
+++ b/docs/creative/specs/LEVEL1_PARALLAX.json
@@ -1,0 +1,57 @@
+{
+  "levelId": "level1_city_above_clouds",
+  "displayName": "City Above Clouds",
+  "budgets": { "parallaxLayers": 5, "particleBurstPeak": 300 },
+  "parallax": {
+    "scrollDirection": "left",
+    "tileWidth": 1280,
+    "tileHeight": 720,
+    "layers": [
+      {
+        "id": "far_clouds",
+        "name": "Far Clouds",
+        "speed": 0.10,
+        "zIndex": 10,
+        "opacity": 1,
+        "asset": "assets/backgrounds/city/far_clouds.png",
+        "notes": "Soft gradient clouds with star specks"
+      },
+      {
+        "id": "mid_towers",
+        "name": "Stratos Towers",
+        "speed": 0.35,
+        "zIndex": 20,
+        "opacity": 1,
+        "asset": "assets/backgrounds/city/stratos_towers.png",
+        "notes": "Dark silhouettes, low-frequency shapes"
+      },
+      {
+        "id": "mid_billboards",
+        "name": "Billboards & Cables",
+        "speed": 0.50,
+        "zIndex": 30,
+        "opacity": 1,
+        "asset": "assets/backgrounds/city/billboards_cables.png",
+        "notes": "Occasional oscillation/parallax micro-shift"
+      },
+      {
+        "id": "near_overpass",
+        "name": "Overpass & Antennae",
+        "speed": 0.75,
+        "zIndex": 40,
+        "opacity": 1,
+        "asset": "assets/backgrounds/city/overpass_antennae.png",
+        "notes": "Fast scroll; keep silhouettes chunky"
+      },
+      {
+        "id": "fx_sparks",
+        "name": "Foreground FX",
+        "speed": 1.00,
+        "zIndex": 50,
+        "opacity": 0.5,
+        "asset": "generated",
+        "notes": "Sparse particles only on events; avoid clutter"
+      }
+    ]
+  }
+}

--- a/docs/creative/templates/ASSET_BRIEF.md
+++ b/docs/creative/templates/ASSET_BRIEF.md
@@ -1,0 +1,16 @@
+# Asset Brief Template
+
+Name
+- <Asset name>
+
+Type
+- Background | Sprite | FX | UI | Audio
+
+Usage
+- <Where it appears; performance constraints>
+
+Style notes
+- <Palette, silhouette, motion, readability>
+
+Delivery
+- <Format, size, frames, naming>

--- a/docs/creative/templates/LEVEL_PITCH.md
+++ b/docs/creative/templates/LEVEL_PITCH.md
@@ -1,4 +1,4 @@
-# Level 1 Pitch — City Above Clouds
+# Level 1 Pitch: City Above Clouds
 
 One-liner
 - Neon ruins above the cloudline; learn dodge, first powerup, readable chaos.

--- a/docs/creative/templates/LEVEL_PITCH.md
+++ b/docs/creative/templates/LEVEL_PITCH.md
@@ -1,26 +1,35 @@
-# Level Pitch Template
+# Level 1 Pitch — City Above Clouds
 
 One-liner
-- <Unique hook in 12 words>
+- Neon ruins above the cloudline; learn dodge, first powerup, readable chaos.
 
 Core mechanic
-- <What the player learns or is challenged by>
+- Onboarding: basic movement/shooting with generous windows; introduce a risk/reward pickup that charges if held briefly for a stronger effect.
 
 Parallax layers (5)
-- Far:
-- Mid 1:
-- Mid 2:
-- Near:
-- FX:
+- Far: Soft cloud gradient with faint stars; very slow drift (speed ~0.10).
+- Mid 1: Ruined stratos-towers silhouettes; lateral drift (speed ~0.35).
+- Mid 2: Drifting billboards and cable spans; occasional parallax oscillation (speed ~0.50).
+- Near: Overpass debris and antennae; fast scroll (speed ~0.75).
+- FX: Foreground sparks/dust on damage/bursts; sparse for readability (speed ~1.00).
 
 Enemies (2–3 behaviors)
-- 
+- Drone (Flanker): low HP, zig-zag approach, no aim; teaches target prioritization.
+- Turret (Platform): stationary on moving platform; slow telegraphed aimed shots; teaches timing and safe lanes.
+- Optional: Seeder (Low density): drops slow homing seeds that can be shot; introduces hazard clean-up.
 
-Boss (2 phases)
-- 
+Boss (2 phases) — Relay Warden
+- Phase 1: Ring-beam sweeps (telegraph arcs) + fan bullets; safe gaps rotate; occasional drone adds.
+- Phase 2: Core splits into two nodes; alternating sweep patterns with wider gaps; brief vulnerability windows between cycles.
 
 Micro-challenges (2)
-- 
+- "Hold the Line": Take no damage for 20 seconds.
+- "Clean Sweep": Destroy 5 drones while combo ≥ 2x.
 
 Asset list
-- 
+- 5 tileable parallax layers (PNG/SVG), per-layer speeds as above.
+- Drone + Turret sprites (clear silhouettes) and bullet sprites (basic + charged).
+- Boss silhouette with 2 simple anim states; ring-beam telegraph sprite.
+- FX: explosion sheet (8–12 frames), muzzle flash, hit particles, trail.
+- UI: minimal combo meter, micro-challenge prompt badges.
+- Audio: 1 loopable track + boss layer; SFX: shoot, hit, explode, pickup, UI.

--- a/docs/creative/templates/LEVEL_PITCH.md
+++ b/docs/creative/templates/LEVEL_PITCH.md
@@ -1,0 +1,26 @@
+# Level Pitch Template
+
+One-liner
+- <Unique hook in 12 words>
+
+Core mechanic
+- <What the player learns or is challenged by>
+
+Parallax layers (5)
+- Far:
+- Mid 1:
+- Mid 2:
+- Near:
+- FX:
+
+Enemies (2–3 behaviors)
+- 
+
+Boss (2 phases)
+- 
+
+Micro-challenges (2)
+- 
+
+Asset list
+- 

--- a/docs/creative/templates/LORE_SNIPPET.md
+++ b/docs/creative/templates/LORE_SNIPPET.md
@@ -1,0 +1,10 @@
+# Lore Snippet Template
+
+Context
+- <Where/when this log appears>
+
+Text (140–220 chars)
+- "<Concise, evocative line>"
+
+Unlock
+- <What cosmetic/challenge unlocks when found>


### PR DESCRIPTION
This PR adds a new docs/creative hub to focus on content and engagement:

- BACKSTORY: 3 pitches + seeded lines for "Signal of the Last City"
- ART_DIRECTION: style constraints, palettes, readability
- LEVELS_AND_PARALLAX: layer recipes + 4 level arc ideas
- ENGAGEMENT_DESIGN: combo, micro-challenges, momentum, feedback kit
- AUDIO_DIRECTION: music/SFX palette, dynamic hooks
- ASSET_LIST: MVP assets
- PIPELINE: structure, naming, iteration
- ROADMAP: 2–3 week creative push
- templates/: LEVEL_PITCH, LORE_SNIPPET, ASSET_BRIEF

Goal: enable fast brainstorming and small, shippable content experiments.

Planned follow-ups (tracked issues)
- [ ] #50 Creative: Decide backstory pitch (MVP)
- [ ] #51 Creative: Level 1 parallax assets
- [ ] #52 Creative: Implement Level 1 parallax in engine
- [ ] #53 Creative: Enemy set for Level 1 (Drone, Turret, Seeder)
- [ ] #54 Creative: Boss — Relay Warden (Phase 1–2)
- [ ] #55 Engagement: Combo multiplier prototype
- [ ] #56 Engagement: Micro-challenges framework + 2 challenges
- [ ] #57 Audio: Level 1 loop + SFX baseline
- [ ] #58 Art: Placeholder silhouettes and palette for Level 1
