### PR TITLE
feat(assets): Level 1 parallax placeholders (City Above Clouds)

### DIFF
--- a/assets/backgrounds/city/README.md
+++ b/assets/backgrounds/city/README.md
@@ -1,0 +1,14 @@
+# City Background Placeholders
+
+These SVGs are flat, readable placeholders to visualize Level 1 parallax motion. Replace with final art later.
+
+Mapping to spec (docs/creative/specs/LEVEL1_PARALLAX.json)
+- Far Clouds → far_clouds.svg
+- Stratos Towers → stratos_towers.svg
+- Billboards & Cables → billboards_cables.svg
+- Overpass & Antennae → overpass_antennae.svg
+- FX layer is generated; no static asset.
+
+Notes
+- Size: 1280x720 tile width/height. Keep tileable horizontally if exporting to PNG.
+- Palette: Neon Ruins (docs/creative/palettes/NEON_RUINS.json)

--- a/assets/backgrounds/city/billboards_cables.svg
+++ b/assets/backgrounds/city/billboards_cables.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720">
+  <g fill="#0e3460">
+    <rect x="100" y="320" width="220" height="120" rx="8"/>
+    <rect x="520" y="280" width="260" height="140" rx="8"/>
+    <rect x="900" y="300" width="200" height="110" rx="8"/>
+  </g>
+  <g stroke="#2b1b3a" stroke-width="6" fill="none">
+    <path d="M0,260 C200,280 400,240 600,260 S1000,300 1280,260"/>
+    <path d="M0,340 C240,360 480,320 720,340 S1120,380 1280,340"/>
+  </g>
+</svg>

--- a/assets/backgrounds/city/far_clouds.svg
+++ b/assets/backgrounds/city/far_clouds.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0b1022"/>
+      <stop offset="70%" stop-color="#1a1f3b"/>
+      <stop offset="100%" stop-color="#2a2a3e"/>
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="720" fill="url(#g)"/>
+  <g fill="#ffffff" opacity="0.15">
+    <ellipse cx="200" cy="120" rx="120" ry="40"/>
+    <ellipse cx="400" cy="90" rx="100" ry="35"/>
+    <ellipse cx="700" cy="130" rx="130" ry="45"/>
+    <ellipse cx="1000" cy="100" rx="110" ry="38"/>
+  </g>
+</svg>

--- a/assets/backgrounds/city/overpass_antennae.svg
+++ b/assets/backgrounds/city/overpass_antennae.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720">
+  <g fill="#16213e">
+    <rect x="0" y="500" width="1280" height="40"/>
+    <rect x="200" y="470" width="30" height="70"/>
+    <rect x="600" y="460" width="24" height="80"/>
+    <rect x="1000" y="475" width="28" height="65"/>
+  </g>
+  <g stroke="#666" stroke-width="3">
+    <line x1="210" y1="470" x2="210" y2="420"/>
+    <line x1="612" y1="460" x2="612" y2="410"/>
+    <line x1="1014" y1="475" x2="1014" y2="425"/>
+  </g>
+</svg>

--- a/assets/backgrounds/city/stratos_towers.svg
+++ b/assets/backgrounds/city/stratos_towers.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720">
+  <g fill="#1a1f3b">
+    <rect x="50" y="400" width="100" height="220"/>
+    <rect x="250" y="360" width="80" height="260"/>
+    <rect x="420" y="380" width="120" height="240"/>
+    <rect x="650" y="350" width="90" height="270"/>
+    <rect x="850" y="390" width="110" height="230"/>
+    <rect x="1050" y="370" width="95" height="250"/>
+  </g>
+</svg>


### PR DESCRIPTION
Adds placeholder SVGs for Level 1 parallax per spec:

- far_clouds.svg (far layer)
- stratos_towers.svg (mid layer)
- billboards_cables.svg (mid layer)
- overpass_antennae.svg (near layer)

Docs
- Spec: docs/creative/specs/LEVEL1_PARALLAX.json
- Palette: docs/creative/palettes/NEON_RUINS.json

Notes
- FX layer remains generated
- 1280x720 tile size; flat silhouettes for readability

Closes #51